### PR TITLE
feat: getForm

### DIFF
--- a/src/atomForm/atomForm.test.ts
+++ b/src/atomForm/atomForm.test.ts
@@ -107,3 +107,34 @@ test('values type should match with schema type', () => {
       }
   >();
 });
+
+test('set and get with getForm', () => {
+  const fieldAtom = atomWithSchema<string>();
+  const formAtom = atomForm(({ getField }) => ({
+    field: getField(fieldAtom),
+  }));
+
+  const formAtom2 = atomForm(({ getForm }) => ({
+    field2: getForm(formAtom),
+  }));
+
+  const { result: form } = renderHook(() => useAtom(formAtom2));
+
+  act(() => {
+    form.current[1]({
+      field2: {
+        field: '1',
+      },
+    });
+  });
+
+  expect(form.current[0]).toStrictEqual({
+    isValid: true,
+    values: {
+      field2: {
+        field: '1',
+      },
+    },
+  });
+});
+

--- a/src/atomForm/atomForm.ts
+++ b/src/atomForm/atomForm.ts
@@ -9,6 +9,9 @@ type Read<Fields> = (getters: Getters) => {
 type Getters = {
   get: <V>(a: WritableAtom<V, [V], void>) => FieldAtom<V>;
   getField: <V>(a: AtomWithSchema<V>) => FieldAtom<V>;
+  getForm: <V extends Record_>(
+    a: WritableAtom<AtomFormReturn<V>, [V], void>,
+  ) => FieldAtom<V>;
 };
 
 type AtomWithSchema<V> = WritableAtom<
@@ -30,6 +33,14 @@ export function atomForm<V extends Record_>(
       atom(
         get => state2result(get(a).state),
         (get, set, arg) => set(get(a).onChangeInValueAtom, arg),
+      ),
+    getForm: a =>
+      atom(
+        get => {
+          const v = get(a);
+          return v.isValid ? { isValid: true, value: v.values } : v;
+        },
+        (_, set, arg) => set(a, arg),
       ),
   });
 

--- a/src/atomForm/atomForm.ts
+++ b/src/atomForm/atomForm.ts
@@ -3,21 +3,13 @@ import { AtomWithSchemaReturn } from '../atomWithSchema/atomWithSchema';
 import { FieldState } from '../atomWithSchema/fieldState';
 
 type Read<Fields> = (getters: Getters) => {
-  [K in keyof Fields]: WritableAtom<FieldResult<Fields[K]>, [Fields[K]], void>;
+  [K in keyof Fields]: FieldAtom<Fields[K]>;
 };
 
 type Getters = {
-  get: GetAtom;
-  getField: GetField;
+  get: <V>(a: WritableAtom<V, [V], void>) => FieldAtom<V>;
+  getField: <V>(a: AtomWithSchema<V>) => FieldAtom<V>;
 };
-
-type GetAtom = <V>(
-  a: WritableAtom<V, [V], void>,
-) => WritableAtom<FieldResult<V>, [V], void>;
-
-type GetField = <V>(
-  a: AtomWithSchema<V>,
-) => WritableAtom<FieldResult<V>, [V], void>;
 
 type AtomWithSchema<V> = WritableAtom<
   AtomWithSchemaReturn<V, any, any>,
@@ -105,3 +97,4 @@ const state2result = <V>(state: FieldState<V>): FieldResult<V> => {
 };
 
 type Record_ = Record<string, unknown>;
+type FieldAtom<Value> = WritableAtom<FieldResult<Value>, [Value], void>;


### PR DESCRIPTION
atomForm can be nested

```ts
  const fieldAtom = atomWithSchema<string>();
  const formAtom = atomForm(({ getField }) => ({
    field: getField(fieldAtom),
  }));

  const formAtom2 = atomForm(({ getForm }) => ({
    field2: getForm(formAtom),
  }));

  const { result: form } = renderHook(() => useAtom(formAtom2));
```